### PR TITLE
feat (#8): Criar endpoint para cadastro de fazenda

### DIFF
--- a/src/main/java/com/fatec/api/backend/controller/CidadeController.java
+++ b/src/main/java/com/fatec/api/backend/controller/CidadeController.java
@@ -1,0 +1,27 @@
+package com.fatec.api.backend.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fatec.api.backend.model.Cidade;
+import com.fatec.api.backend.repository.CidadeRepository;
+
+@RestController
+@RequestMapping("/cidade")
+@CrossOrigin(origins= "*")
+public class CidadeController {
+
+    @Autowired
+    private CidadeRepository cidadeRepository;
+
+	@GetMapping("/all")
+	public ResponseEntity<List<Cidade>> getCidade() {
+		return ResponseEntity.ok(cidadeRepository.findAll());
+	}
+}

--- a/src/main/java/com/fatec/api/backend/controller/EstadoController.java
+++ b/src/main/java/com/fatec/api/backend/controller/EstadoController.java
@@ -1,0 +1,27 @@
+package com.fatec.api.backend.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fatec.api.backend.model.Estado;
+import com.fatec.api.backend.repository.EstadoRepository;
+
+@RestController
+@RequestMapping("/estado")
+@CrossOrigin(origins= "*")
+public class EstadoController {
+
+    @Autowired
+    private EstadoRepository estadoRepository;
+
+	@GetMapping("/all")
+	public ResponseEntity<List<Estado>> getCidade() {
+		return ResponseEntity.ok(estadoRepository.findAll());
+	}
+}

--- a/src/main/java/com/fatec/api/backend/controller/FazendaController.java
+++ b/src/main/java/com/fatec/api/backend/controller/FazendaController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import com.fatec.api.backend.model.Fazenda;
 import com.fatec.api.backend.repository.FazendaRepository;
 import com.fatec.api.backend.service.EstadoService;
 import com.fatec.api.backend.service.FazendaService;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
 @RequestMapping("/fazenda")
@@ -32,9 +34,16 @@ public class FazendaController {
     @Autowired
     private FazendaRepository fazendaRepository;
 
+    
     public FazendaController(FazendaService fazendaService, EstadoService estadoService) {
         this.fazendaService = fazendaService;
         this.estadoService = estadoService;
+    }
+
+    @PostMapping()
+    public ResponseEntity<?> createFazenda(@RequestBody Fazenda fazenda) {
+        Fazenda savedFazenda = fazendaService.cadastrarFazenda(fazenda);
+        return ResponseEntity.ok(savedFazenda);
     }
 
     @GetMapping("listar/{page}/{quantity}")

--- a/src/main/java/com/fatec/api/backend/controller/TalhaoController.java
+++ b/src/main/java/com/fatec/api/backend/controller/TalhaoController.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +30,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/talhao")
+@CrossOrigin(origins = "*")
 public class TalhaoController {
 
     @Autowired
@@ -39,12 +41,12 @@ public class TalhaoController {
 
     @PostMapping(consumes = "multipart/form-data")
     public ResponseEntity<Map<String, List<TalhaoDTO>>> createTalhao(
-            @RequestPart("faz_id") String fazId,
-            @RequestPart("file") MultipartFile geoJsonFile) throws ParseException, JsonProcessingException, JsonMappingException {
-    
-            ObjectMapper objectMapper = new ObjectMapper();
-            FazDTO fazDTO = objectMapper.readValue(fazId, FazDTO.class);        
-            try {
+        @RequestPart("faz_id") String fazId,
+        @RequestPart("file") MultipartFile geoJsonFile) throws ParseException, JsonProcessingException, JsonMappingException {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        FazDTO fazDTO = objectMapper.readValue(fazId, FazDTO.class);        
+        try {
             Fazenda fazenda = fazendaRepository.getReferenceById(fazDTO.getFaz_id());
             String geoJsonContent = new String(geoJsonFile.getBytes());
             List<TalhaoDTO> talhoes = talhaoService.createTalhoes(geoJsonContent, fazenda);

--- a/src/main/java/com/fatec/api/backend/model/Cidade.java
+++ b/src/main/java/com/fatec/api/backend/model/Cidade.java
@@ -18,6 +18,7 @@ public class Cidade {
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     @Column(name = "id")
     @Getter
+    @Setter
     private Long id;
 
     @Column(name = "cid_nome")

--- a/src/main/java/com/fatec/api/backend/repository/CidadeRepository.java
+++ b/src/main/java/com/fatec/api/backend/repository/CidadeRepository.java
@@ -1,0 +1,12 @@
+package com.fatec.api.backend.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.fatec.api.backend.model.Cidade;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@Repository
+public interface CidadeRepository extends JpaRepository<Cidade, Long> {
+
+}

--- a/src/main/java/com/fatec/api/backend/service/FazendaService.java
+++ b/src/main/java/com/fatec/api/backend/service/FazendaService.java
@@ -11,8 +11,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import com.fatec.api.backend.model.Cidade;
+import com.fatec.api.backend.model.Estado;
 import com.fatec.api.backend.model.Fazenda;
 import com.fatec.api.backend.model.Usuario;
+import com.fatec.api.backend.repository.CidadeRepository;
+import com.fatec.api.backend.repository.EstadoRepository;
 import com.fatec.api.backend.repository.FazendaRepository;
 
 @Service
@@ -20,12 +24,34 @@ public class FazendaService {
     
     private FazendaRepository fazendaRepository;
 
+    @Autowired
+    private CidadeRepository cidadeRepository;
+    @Autowired
+    private EstadoRepository estadoRepository;
+
     private UsuarioService usuarioService;
 
     @Autowired
     public FazendaService(FazendaRepository fazendaRepository, UsuarioService usuarioService) {
         this.fazendaRepository = fazendaRepository;
         this.usuarioService = usuarioService;
+    }
+
+    public Fazenda cadastrarFazenda(Fazenda fazenda) {
+        Cidade cidade = null;
+        if (fazenda.getCidade().getId() == null) {
+            Cidade cidadeRaw = fazenda.getCidade();
+            Estado estado = estadoRepository.findById(cidadeRaw.getEstado().getId()).get();
+            cidadeRaw.setEstado(estado);
+            cidade = cidadeRepository.save(cidadeRaw);
+        } else {
+            cidade = cidadeRepository.findById(fazenda.getCidade().getId()).get();
+        }
+
+        fazenda.setCidade(cidade);
+            
+        Fazenda savedFazenda = fazendaRepository.save(fazenda);
+        return savedFazenda;
     }
 
     public Page<Fazenda> listarFazendasPaginadas(int page, int size) {

--- a/src/test/java/com/fatec/api/backend/service/FazendaServiceTest.java
+++ b/src/test/java/com/fatec/api/backend/service/FazendaServiceTest.java
@@ -31,7 +31,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
-import com.fatec.api.backend.DTO.EstadoDTO;
 import com.fatec.api.backend.model.Cidade;
 import com.fatec.api.backend.model.Estado;
 import com.fatec.api.backend.model.Fazenda;


### PR DESCRIPTION
Nesse PR foi feito e endpoint para cadastrar uma fazenda nova, cadastrar uma cidade a partir do request da fazenda caso a cidade não exista no banco, e criada um endpoint para listar todas as cidades e estados para o campo autocomplete do frontend.

## Funcionamento
Recebe body JSON no formato

Caso a cidade exista:
```json
{
	"nome": "bar",
	"prodAnual": 20,
	"area": 30,
	"tipoSolo": "Argiloso",
	"cidade": {
        	"id": 1
	}
}
```

Caso a cidade **NÃO** exista
```json
{
	"nome": "bar",
	"prodAnual": 20,
	"area": 30,
	"tipoSolo": "Argiloso",
	"cidade": {
        	"nome": "tal cidade",
        	"estado": {
        	      "id": 1
        	}
	}
}
```


Close #8  